### PR TITLE
Text setup

### DIFF
--- a/src/components/text/CdrText.vue
+++ b/src/components/text/CdrText.vue
@@ -1,29 +1,22 @@
 <template>
   <component
-    :is="tag"
+    :is="props.tag"
     :class="style['cdr-text']"
   >
     <slot />
   </component>
 </template>
 
-<script>
-import { useCssModule, defineComponent } from 'vue';
+<script setup>
+import { useCssModule, defineProps } from 'vue';
 
-export default defineComponent({
-  name: 'CdrText',
-  props: {
-    tag: {
-      type: String,
-      default: 'p',
-    },
+const props = defineProps({
+  tag: {
+    type: String,
+    default: 'p',
   },
-  setup() {
-    return {
-      style: useCssModule(),
-    }
-  }
 });
+const style = useCssModule();
 </script>
 
 <style lang="scss" module src="./styles/CdrText.module.scss">

--- a/src/components/text/examples/demo/Headings.vue
+++ b/src/components/text/examples/demo/Headings.vue
@@ -1,5 +1,15 @@
 <template>
   <div>
+    <div data-backstop="heading-display">
+      <h3>Heading Display</h3>
+      <cdr-text
+        v-for="level in heading.display"
+        :class="`cdr-text-dev--heading-display-${level}`"
+        :key="`heading-display-${level}`"
+      >
+        Heading Display {{ level }}
+      </cdr-text>
+    </div>
     <div data-backstop="heading-serif">
       <h3>Heading Serif</h3>
       <cdr-text
@@ -56,6 +66,7 @@ export default {
   data() {
     return {
       heading: {
+        display: [800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600],
         serif: [200, 300, 400, 500, 600, 700, 800, 900, 1100, 1200],
         serifStrong: [600, 700, 800, 900, 1100, 1200],
         sans: [200, 300, 400, 500, 600],

--- a/src/dev/Dev.vue
+++ b/src/dev/Dev.vue
@@ -231,6 +231,17 @@ export default {
   }
 
   &--heading {
+    &-display {
+      &-800 { @include cdr-text-heading-display-800; }
+      &-900 { @include cdr-text-heading-display-900; }
+      &-1000 { @include cdr-text-heading-display-1000; }
+      &-1100 { @include cdr-text-heading-display-1100; }
+      &-1200 { @include cdr-text-heading-display-1200; }
+      &-1300 { @include cdr-text-heading-display-1300; }
+      &-1400 { @include cdr-text-heading-display-1400; }
+      &-1500 { @include cdr-text-heading-display-1500; }
+      &-1600 { @include cdr-text-heading-display-1600; }
+    }
     &-sans {
       &-200 { @include cdr-text-heading-sans-200; }
       &-300 { @include cdr-text-heading-sans-300; }


### PR DESCRIPTION
- Text component now uses `script setup` sugar
- Brings heading display examples over from main library