### PR TITLE
refactor(script setup): refactor caption, moving script block to top

### DIFF
--- a/src/components/caption/CdrCaption.vue
+++ b/src/components/caption/CdrCaption.vue
@@ -4,7 +4,6 @@ import {
   defineComponent, 
   useCssModule 
 } from 'vue';
-import { buildClass } from '../../utils/buildClass';
 
 const props = defineProps({
   summary: {

--- a/src/components/caption/CdrCaption.vue
+++ b/src/components/caption/CdrCaption.vue
@@ -1,3 +1,27 @@
+<script setup>
+
+import { 
+  defineComponent, 
+  useCssModule 
+} from 'vue';
+import { buildClass } from '../../utils/buildClass';
+
+const props = defineProps({
+  summary: {
+    type: String,
+  },
+  credit: {
+    type: String,
+  },
+});
+
+const baseClass = 'cdr-caption';
+const style = useCssModule();
+const summaryClass = 'cdr-caption__summary';
+const citeClass = 'cdr-caption__cite';
+
+</script>
+
 <template>
   <div :class="style[baseClass]">
     <p
@@ -14,27 +38,6 @@
     </cite>
   </div>
 </template>
-
-<script>
-
-import { defineComponent, useCssModule } from 'vue';
-
-export default defineComponent({
-  name: 'CdrCaption',
-  props: {
-    summary: String,
-    credit: String,
-  },
-  setup() {
-    return {
-      style: useCssModule(),
-      baseClass: 'cdr-caption',
-      summaryClass: 'cdr-caption__summary',
-      citeClass: 'cdr-caption__cite',
-    };
-  },
-});
-</script>
 
 <style lang="scss" module src="./styles/CdrCaption.module.scss">
 </style>

--- a/src/components/caption/CdrCaption.vue
+++ b/src/components/caption/CdrCaption.vue
@@ -1,8 +1,7 @@
 <script setup>
 
 import { 
-  defineComponent, 
-  useCssModule 
+  useCssModule
 } from 'vue';
 
 const props = defineProps({


### PR DESCRIPTION
## Description

just playing around to see how things are going - it looks like the default vite template generates the script block over the template - as we had talked of moving to this pattern I updated this component to have a convo 

## Checklist:

- [x ] script setup
- [x ] moved script block above template

### Unit testing:
- [ -] tests have not been altered 

### A11y:
- [x ] Meets WCAG AA standards
