### PR TITLE
fix(chip): forces the svg icon to inherit the chip's fill to address …

### DIFF
--- a/src/components/chip/styles/CdrChip.module.scss
+++ b/src/components/chip/styles/CdrChip.module.scss
@@ -7,10 +7,16 @@
 
 .cdr-chip__icon-left {
   @include cdr-chip-icon-left-mixin;
+  & svg {
+    fill: inherit;
+  }
 }
 
 .cdr-chip__icon-right {
   @include cdr-chip-icon-right-mixin;
+  & svg {
+    fill: inherit;
+  }
 }
 
 .cdr-chip__icon-left ~ .cdr-chip__content {


### PR DESCRIPTION
https://issues.rei.com/browse/CDR-2352