### PR TITLE
Adds `.dist/` to `package.json.exports`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rei/cedar",
-  "version": "13.0.0-beta.0",
+  "version": "13.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rei/cedar",
-      "version": "13.0.0-beta.0",
+      "version": "13.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "lodash-es": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cedar",
-  "version": "13.0.0-beta.0",
+  "version": "13.0.0-beta.1",
   "description": "REI Cedar Component Library",
   "homepage": "https://rei.github.io/rei-cedar/",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     ".": {
       "import": "./dist/cedar.es.js",
       "require": "./dist/cedar.umd.js"
-    }
+    },
+    "./dist/": "./dist/"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Brought in `@rei/cedar@13.0.0-beta.0` to our `climbers-site` branch that replaces `@rei/febs` with `vite`. Attempted to import a static CSS file from `@rei/cedar/dist/style/...` and was getting a build-time error

```vue
<style lang="scss">
@import "@rei/cdr-tokens/dist/scss/cdr-tokens.scss";
@import "@rei/cedar/dist/style/cdr-container.css"; // <--causing error

.stack > * + * {
  margin-top: $cdr-space-three-x;
}
.stack_small > * + * {
  margin-top: $cdr-space-one-x;
}
</style>
```

```sh
> climber@3.3.1 build
> vite build

vite v2.9.6 building for production...
✓ 18 modules transformed.
[vite:css] Missing "./dist/style/cdr-container.css" export in "@rei/cedar" package
file: /Users/kmedley/code/climbers-site/climbers-site/src/main/js/pages/climber/ClimberPageComponent.vue?vue&type=style&index=0&lang.scss
error during build:
Error: Missing "./dist/style/cdr-container.css" export in "@rei/cedar" package
    at bail (/Users/kmedley/code/climbers-site/climbers-site/node_modules/vite/dist/node/chunks/dep-3397b401.js:39847:8)
    at resolve (/Users/kmedley/code/climbers-site/climbers-site/node_modules/vite/dist/node/chunks/dep-3397b401.js:39924:10)
    at resolveExports (/Users/kmedley/code/climbers-site/climbers-site/node_modules/vite/dist/node/chunks/dep-3397b401.js:40590:12)
    at resolveDeepImport (/Users/kmedley/code/climbers-site/climbers-site/node_modules/vite/dist/node/chunks/dep-3397b401.js:40608:31)
    at tryNodeResolve (/Users/kmedley/code/climbers-site/climbers-site/node_modules/vite/dist/node/chunks/dep-3397b401.js:40381:20)
    at Context.resolveId (/Users/kmedley/code/climbers-site/climbers-site/node_modules/vite/dist/node/chunks/dep-3397b401.js:40189:28)
    at Object.resolveId (/Users/kmedley/code/climbers-site/climbers-site/node_modules/vite/dist/node/chunks/dep-3397b401.js:38754:55)
    at async Object.<anonymous> (/Users/kmedley/code/climbers-site/climbers-site/node_modules/vite/dist/node/chunks/dep-3397b401.js:61351:27)
    at async Object.resolve (/Users/kmedley/code/climbers-site/climbers-site/node_modules/vite/dist/node/chunks/dep-3397b401.js:30055:34)
    at async LazyResult.runAsync (/Users/kmedley/code/climbers-site/climbers-site/node_modules/postcss/lib/lazy-result.js:396:11)
```
It appears that `vite` strictly adheres to the `exports` property in `package.json` at build-time. This PR adds `.dist/` to `package.json.exports` property so that all `dist` assets are consumable via `import` statement.

Tested this by manually adding the additional export directly in the Cedar dep within the branch and everything worked as expected.

```sh
> climber@3.3.1 build
> vite build

vite v2.9.6 building for production...
✓ 25 modules transformed.
target/classes/dist/manifest.json                  0.21 KiB
target/classes/dist/assets/climbers.277688d9.css   3.89 KiB / gzip: 1.01 KiB
target/classes/dist/assets/climbers.b5e5cceb.js    180.09 KiB / gzip: 38.55 KiB
target/classes/dist/assets/climbers.b5e5cceb.js.map 982.91 KiB
```