### PR TITLE
fix(tooltip): aria-describedby needs to wrap text directly

### DIFF
--- a/src/components/tooltip/examples/Tooltip.vue
+++ b/src/components/tooltip/examples/Tooltip.vue
@@ -71,11 +71,8 @@
           tooltip
         </cdr-button>
       </template>
-
-      <div>
         Hello! This tooltip contains important information about the web site you are visiting!
         We're using the internet right now!
-      </div>
     </cdr-tooltip>
 
     <hr>
@@ -102,10 +99,8 @@
         @opened="tooltipHandler"
         @closed="tooltipHandler"
       >
-        <div>
-          Hello! This tooltip contains important information about the web site you are visiting!
-          We're using the internet right now!
-        </div>
+        Hello! This tooltip contains important information about the web site you are visiting!
+        We're using the internet right now!
       </cdr-tooltip>
 
     </div>


### PR DESCRIPTION
CDR-2331
@benjag , not sure if there is a reason the example slots in the tooltip are wrapped in a div, as this causes the text to be nested from the ID used by aria-describedby we are seeing an error - https://issues.rei.com/browse/CDR-2331

### A11y:
- [ x] Meets WCAG AA standards

### Documentation:
- [x ] Examples created/updated
